### PR TITLE
fix: udp_utils should not randomly print file paths

### DIFF
--- a/src/utils/udp_utils/index.ts
+++ b/src/utils/udp_utils/index.ts
@@ -130,7 +130,6 @@ export function UDPRequest (_this: AnidbUDPClient, command: string, request: Req
         if (respDecodedBuffer[0] === 0 && respDecodedBuffer[1] === 0) {
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           const filePath = require('path').resolve(__dirname, '../../compressedResult')
-          console.log(filePath)
           fs.writeFileSync(filePath, respDecodedBuffer.toString('base64'))
 
           respDecodedBuffer = await decompress(respDecodedBuffer)


### PR DESCRIPTION
Even with debug disable a lot of random text is logged to console, rather annoying when trying to use this in a small cli tool.
Most seem to come from this one. Seems left over from some sort of debugging.

e.g.
```
[II] akiba v1.0.2
--------------------------------------------------------------------------------
[II] Target Path: /srv/downloads/Anime
[II] Format: {anime_name_romaji:upper_first}/{anime_name_romaji}/{anime_name_romaji} - {episode:number} - {episode_name} ({crc32:lower}).{filetype}
[II] Renaming files ...
[>>] Shin Bible Black - 1 - Revival (04995C14).mkv: Identifying ...
/home/sjorge/_repos/akiba/node_modules/anidb-udp-client/dist/compressedResult
[OK] Shin Bible Black - 1 - Revival (04995C14).mkv: Identifying ...
```

Is now 
```
[II] akiba v1.0.2
--------------------------------------------------------------------------------
[II] Target Path: /srv/downloads/Anime
[II] Format: {anime_name_romaji:upper_first}/{anime_name_romaji}/{anime_name_romaji} - {episode:number} - {episode_name} ({crc32:lower}).{filetype}
[II] Renaming files ...
[>>] Shin Bible Black - 1 - Revival (04995C14).mkv: Identifying ...
[OK] Shin Bible Black - 1 - Revival (04995C14).mkv: Identifying ...
```
